### PR TITLE
Add support for Upstart based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ It only supports verified TLS connections and defaults to using the Puppet certi
 It's recommended that you define a cluster of servers equal to 3 nodes, but it can run
 standalone too.
 
-Logging is to syslog and various paths can be configured via the class properties.
+Logging is to syslog for `systemd` and to `/var/log/upstart/gnatsd.log` for
+`upstart`. Various other paths can be configured via the class properties.
 
 By default clients will use port `4222`, monitoring will be on port `8222` and cluster comms will use port `4223`.
 
@@ -40,6 +41,25 @@ If you do not specify servers, it becomes a standalone node:
 include nats
 ```
 
+### Select the service type (`systemd` or `upstart`)
+
+The default service type is `systemd`. The module will install a systemd unit file:
+
+```puppet
+class{"nats":
+  service_type => "systemd", # the default
+}
+```
+
+On distributions like Ubuntu 12.04 and 14.04 you should set the system type to
+`upstart`. The module will install an Upstart job:
+
+```puppet
+class{"nats":
+  service_type => "upstart",
+}
+```
+
 ### Collectd Stats
 
 If you use the `puppet/collectd` module to manage collectd this module can configure a metrics
@@ -55,4 +75,7 @@ class{"nats":
 
 ## Compatibility
 
-It only supports Systemd based Debian and RedHat systems via the `camptocamp/systemd` module.
+It supports Systemd based Debian and RedHat systems via the
+`camptocamp/systemd` and Upstart based systems like Ubuntu. Use the
+`nats::service_type` parameter to select either `systemd` (the default) or
+`upstart`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class nats (
   String $piddir = "/var/run",
   String $binary_source = "puppet:///modules/nats/gnatsd-0.9.4",
   String $service_name = "gnatsd",
+  Enum['systemd', 'upstart'] $service_type = 'systemd',
   String $cert_file = "/etc/puppetlabs/puppet/ssl/certs/${facts['networking']['fqdn']}.pem",
   String $key_file = "/etc/puppetlabs/puppet/ssl/private_keys/${facts['networking']['fqdn']}.pem",
   String $ca_file = "/etc/puppetlabs/puppet/ssl/certs/ca.pem",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,21 +1,17 @@
 class nats::install {
-  include systemd
+  contain "nats::install::${nats::service_type}"
 
   file {
     default:
-      owner  => "root",
-      group  => "root",
-      mode   => "0755";
+      owner => "root",
+      group => "root",
+      mode  => "0755";
 
     $nats::binpath:
       source => $nats::binary_source;
 
     $nats::configdir:
       ensure => "directory";
-  }
-
-  systemd::unit_file {"${nats::service_name}.service":
-    content => epp("nats/systemd_service.epp")
   }
 
   Class[$name] ~> Class["nats::service"]

--- a/manifests/install/systemd.pp
+++ b/manifests/install/systemd.pp
@@ -1,0 +1,7 @@
+class nats::install::systemd {
+  contain '::systemd'
+
+  systemd::unit_file {"${nats::service_name}.service":
+    content => epp('nats/systemd_service.epp'),
+  }
+}

--- a/manifests/install/upstart.pp
+++ b/manifests/install/upstart.pp
@@ -1,0 +1,19 @@
+class nats::install::upstart {
+
+  file { 'gnatsd.upstart':
+    ensure  => 'present',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    path    => '/etc/init/gnatsd.conf',
+    content => epp('nats/upstart_job.epp'),
+  }
+
+  # Create an init.d symlink for convenience:
+  # ln -s /lib/init/upstart-job /etc/init.d/gnatsd
+  file { 'gnatsd upstart initd symlink':
+    ensure => 'link',
+    target => '/lib/init/upstart-job',
+    path   => '/etc/init.d/gnatsd'
+  }
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,7 @@
 class nats::service {
   service{$nats::service_name:
-    ensure => "running",
-    enable => true
+    ensure   => "running",
+    enable   => true,
+    provider => $nats::service_type,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,14 @@
       ]
     },
     {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "12.04",
+	"14.04",
+	"16.04"
+      ]
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7"

--- a/templates/upstart_job.epp
+++ b/templates/upstart_job.epp
@@ -1,0 +1,18 @@
+# NATS.io Messaging System Server (gnatsd)
+#
+# NATS is an open source, lightweight, high-performance cloud native
+# infrastructure messaging system.
+#
+# This Upstart job is installed and managed by Puppet.
+
+description "NATS.io Messaging System Server"
+
+start on runlevel [2345]
+stop on runlevel ![2345]
+
+respawn
+respawn limit 10 5
+
+console log
+
+exec <%= $nats::binpath %> --config <%= $nats::configdir %>/<%= $nats::service_name %>.cfg


### PR DESCRIPTION
Add a class parameter nats::service_type which defaults to "systemd" but
can be set to "upstart" for Upstart based systems like Ubuntu 12.04 and
14.04. This will install an Upstart job in /etc/init/gnatsd.conf.

Includes updated spec tests and documentation.